### PR TITLE
Fix negative result for `list --total` with ongoing task

### DIFF
--- a/z/entry.go
+++ b/z/entry.go
@@ -131,6 +131,9 @@ func (entry *Entry) GetOutputForTrack(isRunning bool, wasRunning bool) (string) 
 
 func (entry *Entry) GetDuration() (decimal.Decimal) {
   duration := entry.Finish.Sub(entry.Begin)
+  if (duration < 0) { 
+    duration = time.Now().Sub(entry.Begin)
+  }
   return decimal.NewFromFloat(duration.Hours())
 }
 


### PR DESCRIPTION
closes #11 

Basically just check if `entry.GetDuration()` is less than zero before returning, and if it is, return duration between `time.Now()` and `.Begin()`

It seems to work :D