### PR TITLE
Use now to parse since and until dates

### DIFF
--- a/z/exportCmd.go
+++ b/z/exportCmd.go
@@ -5,6 +5,7 @@ import (
   "fmt"
   "time"
   "encoding/json"
+  "github.com/jinzhu/now"
   "github.com/spf13/cobra"
 )
 
@@ -48,7 +49,7 @@ var exportCmd = &cobra.Command{
     var untilTime time.Time
 
     if since != "" {
-      sinceTime, err = time.Parse(time.RFC3339, since)
+      sinceTime, err = now.Parse(since)
       if err != nil {
         fmt.Printf("%s %+v\n", CharError, err)
         os.Exit(1)
@@ -56,7 +57,7 @@ var exportCmd = &cobra.Command{
     }
 
     if until != "" {
-      untilTime, err = time.Parse(time.RFC3339, until)
+      untilTime, err = now.Parse(until)
       if err != nil {
         fmt.Printf("%s %+v\n", CharError, err)
         os.Exit(1)

--- a/z/listCmd.go
+++ b/z/listCmd.go
@@ -5,6 +5,7 @@ import (
   "os"
   "time"
 
+  "github.com/jinzhu/now"
   "github.com/shopspring/decimal"
   "github.com/spf13/cobra"
 )
@@ -32,7 +33,7 @@ var listCmd = &cobra.Command{
     var untilTime time.Time
 
     if since != "" {
-      sinceTime, err = time.Parse(time.RFC3339, since)
+      sinceTime, err = now.Parse(since)
       if err != nil {
         fmt.Printf("%s %+v\n", CharError, err)
         os.Exit(1)
@@ -40,7 +41,7 @@ var listCmd = &cobra.Command{
     }
 
     if until != "" {
-      untilTime, err = time.Parse(time.RFC3339, until)
+      untilTime, err = now.Parse(until)
       if err != nil {
         fmt.Printf("%s %+v\n", CharError, err)
         os.Exit(1)


### PR DESCRIPTION
These commands, at least in my experience, are usually used using dates and RFC3339 is too verbose for that purpose. There's other commands where I would like to use a mix of dates (like the ones parsed by `now`) and relative time (`+03:36`), like `zeit entry`, but that would probably need something that detects what kind of date it is and choose accordingly.

- Would you be interested in such a change?
- Why is this project not using gofmt/goimports? It's annoying to have to override my editor's behaviour :')

Thank you for zeit!