### PR TITLE
fix error on creation of the very first task

### DIFF
--- a/z/database.go
+++ b/z/database.go
@@ -165,6 +165,9 @@ func (database *Database) GetRunningEntryId(user string) (string, error) {
 
   dberr := database.DB.View(func(tx *buntdb.Tx) error {
     value, err := tx.Get(user + ":status:running")
+    if errors.Is(err, buntdb.ErrNotFound) {
+      return nil
+    }
     if err != nil {
       return err
     }


### PR DESCRIPTION
When creating the very first entry with `zeit track` one only gets the message "▲ not found" and no task is created at all. Basically it's impossible to start tracking time with a fresh installation/db.

Here is a fix for that issue.
Hope it's fine as is, I'm not familiar with BuntDB. Please let me know if it needs further adjustments.