### PR TITLE
Added the additional flags without formatting

### DIFF
--- a/z/entry.go
+++ b/z/entry.go
@@ -1,224 +1,227 @@
 package z
 
 import (
-  "errors"
-  "strings"
-  "time"
-  "fmt"
-  "github.com/gookit/color"
-  "github.com/shopspring/decimal"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/gookit/color"
+	"github.com/shopspring/decimal"
 )
 
 type Entry struct {
-  ID      string      `json:"-"`
-  Begin   time.Time   `json:"begin,omitempty"`
-  Finish  time.Time   `json:"finish,omitempty"`
-  Project string      `json:"project,omitempty"`
-  Task    string      `json:"task,omitempty"`
-  Notes   string      `json:"notes,omitempty"`
-  User    string      `json:"user,omitempty"`
+	ID      string    `json:"-"`
+	Begin   time.Time `json:"begin,omitempty"`
+	Finish  time.Time `json:"finish,omitempty"`
+	Project string    `json:"project,omitempty"`
+	Task    string    `json:"task,omitempty"`
+	Notes   string    `json:"notes,omitempty"`
+	User    string    `json:"user,omitempty"`
 
-  SHA1    string      `json:"-"`
+	SHA1 string `json:"-"`
 }
 
 func NewEntry(
-  id string,
-  begin string,
-  finish string,
-  project string,
-  task string,
-  user string) (Entry, error) {
-  var err error
+	id string,
+	begin string,
+	finish string,
+	project string,
+	task string,
+	user string) (Entry, error) {
+	var err error
 
-  newEntry := Entry{}
+	newEntry := Entry{}
 
-  newEntry.ID = id
-  newEntry.Project = project
-  newEntry.Task = task
-  newEntry.User = user
+	newEntry.ID = id
+	newEntry.Project = project
+	newEntry.Task = task
+	newEntry.User = user
 
-  _, err = newEntry.SetBeginFromString(begin)
-  if err != nil {
-    return Entry{}, err
-  }
+	_, err = newEntry.SetBeginFromString(begin)
+	if err != nil {
+		return Entry{}, err
+	}
 
-  _, err = newEntry.SetFinishFromString(finish)
-  if err != nil {
-    return Entry{}, err
-  }
+	_, err = newEntry.SetFinishFromString(finish)
+	if err != nil {
+		return Entry{}, err
+	}
 
-  if id == "" && newEntry.IsFinishedAfterBegan() == false {
-    return Entry{}, errors.New("beginning time of tracking cannot be after finish time")
-  }
+	if id == "" && newEntry.IsFinishedAfterBegan() == false {
+		return Entry{}, errors.New("beginning time of tracking cannot be after finish time")
+	}
 
-  return newEntry, nil
+	return newEntry, nil
 }
 
-func (entry *Entry) SetIDFromDatabaseKey(key string) (error) {
-  splitKey := strings.Split(key, ":")
+func (entry *Entry) SetIDFromDatabaseKey(key string) error {
+	splitKey := strings.Split(key, ":")
 
-  if len(splitKey) < 3 || len(splitKey) > 3 {
-    return errors.New("not a valid database key")
-  }
+	if len(splitKey) < 3 || len(splitKey) > 3 {
+		return errors.New("not a valid database key")
+	}
 
-  entry.ID = splitKey[2]
-  return nil
+	entry.ID = splitKey[2]
+	return nil
 }
 
 func (entry *Entry) SetBeginFromString(begin string) (time.Time, error) {
-  var beginTime time.Time
-  var err error
+	var beginTime time.Time
+	var err error
 
-  if begin == "" {
-    beginTime = time.Now()
-  } else {
-    beginTime, err = ParseTime(begin)
-    if err != nil {
-      return beginTime, err
-    }
-  }
+	if begin == "" {
+		beginTime = time.Now()
+	} else {
+		beginTime, err = ParseTime(begin)
+		if err != nil {
+			return beginTime, err
+		}
+	}
 
-  entry.Begin = beginTime
-  return beginTime, nil
+	entry.Begin = beginTime
+	return beginTime, nil
+}
+
 }
 
 func (entry *Entry) SetFinishFromString(finish string) (time.Time, error) {
-  var finishTime time.Time
-  var err error
+	var finishTime time.Time
+	var err error
 
-  if finish != "" {
-    finishTime, err = ParseTime(finish)
-    if err != nil {
-      return finishTime, err
-    }
-  }
+	if finish != "" {
+		finishTime, err = ParseTime(finish)
+		if err != nil {
+			return finishTime, err
+		}
+	}
 
-  entry.Finish = finishTime
-  return finishTime, nil
+	entry.Finish = finishTime
+	return finishTime, nil
 }
 
-func (entry *Entry) IsFinishedAfterBegan() (bool) {
-  return (entry.Finish.IsZero() || entry.Begin.Before(entry.Finish))
+func (entry *Entry) IsFinishedAfterBegan() bool {
+	return (entry.Finish.IsZero() || entry.Begin.Before(entry.Finish))
 }
 
-func (entry *Entry) GetOutputForTrack(isRunning bool, wasRunning bool) (string) {
-  var outputPrefix string = ""
-  var outputSuffix string = ""
+func (entry *Entry) GetOutputForTrack(isRunning bool, wasRunning bool) string {
+	var outputPrefix string = ""
+	var outputSuffix string = ""
 
-  now := time.Now()
-  trackDiffNow := now.Sub(entry.Begin)
-  durationString := fmtDuration(trackDiffNow)
+	now := time.Now()
+	trackDiffNow := now.Sub(entry.Begin)
+	durationString := fmtDuration(trackDiffNow)
 
-  if isRunning == true && wasRunning == false {
-    outputPrefix = "began tracking"
-  } else if isRunning == true && wasRunning == true {
-    outputPrefix = "tracking"
-    outputSuffix = fmt.Sprintf(" for %sh", color.FgLightWhite.Render(durationString))
-  } else if isRunning == false && wasRunning == false {
-    outputPrefix = "tracked"
-  }
+	if isRunning == true && wasRunning == false {
+		outputPrefix = "began tracking"
+	} else if isRunning == true && wasRunning == true {
+		outputPrefix = "tracking"
+		outputSuffix = fmt.Sprintf(" for %sh", color.FgLightWhite.Render(durationString))
+	} else if isRunning == false && wasRunning == false {
+		outputPrefix = "tracked"
+	}
 
-  if entry.Task != "" && entry.Project != "" {
-    return fmt.Sprintf("%s %s %s on %s%s\n", CharTrack, outputPrefix, color.FgLightWhite.Render(entry.Task), color.FgLightWhite.Render(entry.Project), outputSuffix)
-  } else if entry.Task != "" && entry.Project == "" {
-    return fmt.Sprintf("%s %s %s%s\n", CharTrack, outputPrefix, color.FgLightWhite.Render(entry.Task), outputSuffix)
-  } else if entry.Task == "" && entry.Project != "" {
-    return fmt.Sprintf("%s %s task on %s%s\n", CharTrack, outputPrefix, color.FgLightWhite.Render(entry.Project), outputSuffix)
-  }
+	if entry.Task != "" && entry.Project != "" {
+		return fmt.Sprintf("%s %s %s on %s%s\n", CharTrack, outputPrefix, color.FgLightWhite.Render(entry.Task), color.FgLightWhite.Render(entry.Project), outputSuffix)
+	} else if entry.Task != "" && entry.Project == "" {
+		return fmt.Sprintf("%s %s %s%s\n", CharTrack, outputPrefix, color.FgLightWhite.Render(entry.Task), outputSuffix)
+	} else if entry.Task == "" && entry.Project != "" {
+		return fmt.Sprintf("%s %s task on %s%s\n", CharTrack, outputPrefix, color.FgLightWhite.Render(entry.Project), outputSuffix)
+	}
 
-  return fmt.Sprintf("%s %s task%s\n", CharTrack, outputPrefix, outputSuffix)
+	return fmt.Sprintf("%s %s task%s\n", CharTrack, outputPrefix, outputSuffix)
 }
 
-func (entry *Entry) GetDuration() (decimal.Decimal) {
-  duration := entry.Finish.Sub(entry.Begin)
-  if (duration < 0) {
-    duration = time.Now().Sub(entry.Begin)
-  }
-  return decimal.NewFromFloat(duration.Hours())
+func (entry *Entry) GetDuration() decimal.Decimal {
+	duration := entry.Finish.Sub(entry.Begin)
+	if duration < 0 {
+		duration = time.Now().Sub(entry.Begin)
+	}
+	return decimal.NewFromFloat(duration.Hours())
 }
 
-func (entry *Entry) GetOutputForFinish() (string) {
-  var outputSuffix string = ""
+func (entry *Entry) GetOutputForFinish() string {
+	var outputSuffix string = ""
 
-  trackDiff := entry.Finish.Sub(entry.Begin)
-  taskDuration := fmtDuration(trackDiff)
+	trackDiff := entry.Finish.Sub(entry.Begin)
+	taskDuration := fmtDuration(trackDiff)
 
-  outputSuffix = fmt.Sprintf(" for %sh", color.FgLightWhite.Render(taskDuration))
+	outputSuffix = fmt.Sprintf(" for %sh", color.FgLightWhite.Render(taskDuration))
 
-  if entry.Task != "" && entry.Project != "" {
-    return fmt.Sprintf("%s finished tracking %s on %s%s\n", CharFinish, color.FgLightWhite.Render(entry.Task), color.FgLightWhite.Render(entry.Project), outputSuffix)
-  } else if entry.Task != "" && entry.Project == "" {
-    return fmt.Sprintf("%s finished tracking %s%s\n", CharFinish, color.FgLightWhite.Render(entry.Task), outputSuffix)
-  } else if entry.Task == "" && entry.Project != "" {
-    return fmt.Sprintf("%s finished tracking task on %s%s\n", CharFinish, color.FgLightWhite.Render(entry.Project), outputSuffix)
-  }
+	if entry.Task != "" && entry.Project != "" {
+		return fmt.Sprintf("%s finished tracking %s on %s%s\n", CharFinish, color.FgLightWhite.Render(entry.Task), color.FgLightWhite.Render(entry.Project), outputSuffix)
+	} else if entry.Task != "" && entry.Project == "" {
+		return fmt.Sprintf("%s finished tracking %s%s\n", CharFinish, color.FgLightWhite.Render(entry.Task), outputSuffix)
+	} else if entry.Task == "" && entry.Project != "" {
+		return fmt.Sprintf("%s finished tracking task on %s%s\n", CharFinish, color.FgLightWhite.Render(entry.Project), outputSuffix)
+	}
 
-  return fmt.Sprintf("%s finished tracking task%s\n", CharFinish, outputSuffix)
+	return fmt.Sprintf("%s finished tracking task%s\n", CharFinish, outputSuffix)
 }
 
-func (entry *Entry) GetOutput(full bool) (string) {
-  var output string = ""
-  var entryFinish time.Time
-  var isRunning string = ""
+func (entry *Entry) GetOutput(full bool) string {
+	var output string = ""
+	var entryFinish time.Time
+	var isRunning string = ""
 
-  if entry.Finish.IsZero() {
-    entryFinish = time.Now()
-    isRunning = "[running]"
-  } else {
-    entryFinish = entry.Finish
-  }
+	if entry.Finish.IsZero() {
+		entryFinish = time.Now()
+		isRunning = "[running]"
+	} else {
+		entryFinish = entry.Finish
+	}
 
-  trackDiff := entryFinish.Sub(entry.Begin)
-  taskDuration := fmtDuration(trackDiff)
-  if full == false {
+	trackDiff := entryFinish.Sub(entry.Begin)
+	taskDuration := fmtDuration(trackDiff)
+	if full == false {
 
-    output = fmt.Sprintf("%s %s on %s from %s to %s (%sh) %s",
-      color.FgGray.Render(entry.ID),
-      color.FgLightWhite.Render(entry.Task),
-      color.FgLightWhite.Render(entry.Project),
-      color.FgLightWhite.Render(entry.Begin.Format("2006-01-02 15:04 -0700")),
-      color.FgLightWhite.Render(entryFinish.Format("2006-01-02 15:04 -0700")),
-      color.FgLightWhite.Render(taskDuration) ,
-      color.FgLightYellow.Render(isRunning),
-    )
-  } else {
-    output = fmt.Sprintf("%s\n   %s on %s\n   %sh from %s to %s %s\n\n   Notes:\n   %s\n",
-      color.FgGray.Render(entry.ID),
-      color.FgLightWhite.Render(entry.Task),
-      color.FgLightWhite.Render(entry.Project),
-      color.FgLightWhite.Render(taskDuration),
-      color.FgLightWhite.Render(entry.Begin.Format("2006-01-02 15:04 -0700")),
-      color.FgLightWhite.Render(entryFinish.Format("2006-01-02 15:04 -0700")),
-      color.FgLightYellow.Render(isRunning),
-      color.FgLightWhite.Render(strings.Replace(entry.Notes, "\n", "\n   ", -1)),
-    )
-  }
+		output = fmt.Sprintf("%s %s on %s from %s to %s (%sh) %s",
+			color.FgGray.Render(entry.ID),
+			color.FgLightWhite.Render(entry.Task),
+			color.FgLightWhite.Render(entry.Project),
+			color.FgLightWhite.Render(entry.Begin.Format("2006-01-02 15:04 -0700")),
+			color.FgLightWhite.Render(entryFinish.Format("2006-01-02 15:04 -0700")),
+			color.FgLightWhite.Render(taskDuration),
+			color.FgLightYellow.Render(isRunning),
+		)
+	} else {
+		output = fmt.Sprintf("%s\n   %s on %s\n   %sh from %s to %s %s\n\n   Notes:\n   %s\n",
+			color.FgGray.Render(entry.ID),
+			color.FgLightWhite.Render(entry.Task),
+			color.FgLightWhite.Render(entry.Project),
+			color.FgLightWhite.Render(taskDuration),
+			color.FgLightWhite.Render(entry.Begin.Format("2006-01-02 15:04 -0700")),
+			color.FgLightWhite.Render(entryFinish.Format("2006-01-02 15:04 -0700")),
+			color.FgLightYellow.Render(isRunning),
+			color.FgLightWhite.Render(strings.Replace(entry.Notes, "\n", "\n   ", -1)),
+		)
+	}
 
-  return output
+	return output
 }
 
 func GetFilteredEntries(entries []Entry, project string, task string, since time.Time, until time.Time) ([]Entry, error) {
-  var filteredEntries []Entry
+	var filteredEntries []Entry
 
-  for _, entry := range entries {
-    if project != "" && GetIdFromName(entry.Project) != GetIdFromName(project) {
-      continue
-    }
+	for _, entry := range entries {
+		if project != "" && GetIdFromName(entry.Project) != GetIdFromName(project) {
+			continue
+		}
 
-    if task != "" && GetIdFromName(entry.Task) != GetIdFromName(task) {
-      continue
-    }
+		if task != "" && GetIdFromName(entry.Task) != GetIdFromName(task) {
+			continue
+		}
 
-    if since.IsZero() == false && since.Before(entry.Begin) == false && since.Equal(entry.Begin) == false {
-      continue
-    }
+		if since.IsZero() == false && since.Before(entry.Begin) == false && since.Equal(entry.Begin) == false {
+			continue
+		}
 
-    if until.IsZero() == false && until.After(entry.Finish) == false && until.Equal(entry.Finish) == false {
-      continue
-    }
+		if until.IsZero() == false && until.After(entry.Finish) == false && until.Equal(entry.Finish) == false {
+			continue
+		}
 
-    filteredEntries = append(filteredEntries, entry)
-  }
+		filteredEntries = append(filteredEntries, entry)
+	}
 
-  return filteredEntries, nil
+	return filteredEntries, nil
 }

--- a/z/exportCmd.go
+++ b/z/exportCmd.go
@@ -1,112 +1,115 @@
 package z
 
 import (
-  "os"
-  "fmt"
-  "time"
-  "encoding/json"
-  "github.com/jinzhu/now"
-  "github.com/spf13/cobra"
+	"encoding/json"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/jinzhu/now"
+	"github.com/spf13/cobra"
 )
 
 func exportZeitJson(user string, entries []Entry) (string, error) {
-  stringified, err := json.Marshal(entries)
-  if err != nil {
-    return "", err
-  }
+	stringified, err := json.Marshal(entries)
+	if err != nil {
+		return "", err
+	}
 
-  return string(stringified), nil
+	return string(stringified), nil
 }
 
 func exportTymeJson(user string, entries []Entry) (string, error) {
-  tyme := Tyme{}
-  err := tyme.FromEntries(entries)
-  if err != nil {
-    return "", err
-  }
+	tyme := Tyme{}
+	err := tyme.FromEntries(entries)
+	if err != nil {
+		return "", err
+	}
 
-  return tyme.Stringify(), nil
+	return tyme.Stringify(), nil
 }
 
 var exportCmd = &cobra.Command{
-  Use:   "export ([flags])",
-  Short: "Export tracked activities",
-  Long: "Export tracked activities to various formats.",
-  // Args: cobra.ExactArgs(1),
-  Run: func(cmd *cobra.Command, args []string) {
-    var entries []Entry
-    var err error
+	Use:   "export ([flags])",
+	Short: "Export tracked activities",
+	Long:  "Export tracked activities to various formats.",
+	// Args: cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		var entries []Entry
+		var err error
 
-    user := GetCurrentUser()
+		user := GetCurrentUser()
 
-    entries, err = database.ListEntries(user)
-    if err != nil {
-      fmt.Printf("%s %+v\n", CharError, err)
-      os.Exit(1)
-    }
+		entries, err = database.ListEntries(user)
+		if err != nil {
+			fmt.Printf("%s %+v\n", CharError, err)
+			os.Exit(1)
+		}
 
-    var sinceTime time.Time
-    var untilTime time.Time
+		var sinceTime time.Time
+		var untilTime time.Time
 
-    if since != "" {
-      sinceTime, err = now.Parse(since)
-      if err != nil {
-        fmt.Printf("%s %+v\n", CharError, err)
-        os.Exit(1)
-      }
-    }
+		if since != "" {
+			sinceTime, err = now.Parse(since)
+			if err != nil {
+				fmt.Printf("%s %+v\n", CharError, err)
+				os.Exit(1)
+			}
+		}
 
-    if until != "" {
-      untilTime, err = now.Parse(until)
-      if err != nil {
-        fmt.Printf("%s %+v\n", CharError, err)
-        os.Exit(1)
-      }
-    }
+		if until != "" {
+			untilTime, err = now.Parse(until)
+			if err != nil {
+				fmt.Printf("%s %+v\n", CharError, err)
+				os.Exit(1)
+			}
+		}
 
-    var filteredEntries []Entry
-    filteredEntries, err = GetFilteredEntries(entries, project, task, sinceTime, untilTime)
-    if err != nil {
-      fmt.Printf("%s %+v\n", CharError, err)
-      os.Exit(1)
-    }
+		var filteredEntries []Entry
+		filteredEntries, err = GetFilteredEntries(entries, project, task, sinceTime, untilTime)
+		if err != nil {
+			fmt.Printf("%s %+v\n", CharError, err)
+			os.Exit(1)
+		}
 
-    var output string = ""
-    switch(format) {
-    case "zeit":
-      output, err = exportZeitJson(user, filteredEntries)
-      if err != nil {
-        fmt.Printf("%s %+v\n", CharError, err)
-        os.Exit(1)
-      }
-    case "tyme":
-      output, err = exportTymeJson(user, filteredEntries)
-      if err != nil {
-        fmt.Printf("%s %+v\n", CharError, err)
-        os.Exit(1)
-      }
-    default:
-      fmt.Printf("%s specify an export format; see `zeit export --help` for more info\n", CharError)
-      os.Exit(1)
-    }
 
-    fmt.Printf("%s\n", output)
-    return
-  },
+		var output string = ""
+		switch format {
+		case "zeit":
+			output, err = exportZeitJson(user, filteredEntries)
+			if err != nil {
+				fmt.Printf("%s %+v\n", CharError, err)
+				os.Exit(1)
+			}
+		case "tyme":
+			output, err = exportTymeJson(user, filteredEntries)
+			if err != nil {
+				fmt.Printf("%s %+v\n", CharError, err)
+				os.Exit(1)
+			}
+		default:
+			fmt.Printf("%s specify an export format; see `zeit export --help` for more info\n", CharError)
+			os.Exit(1)
+		}
+
+		fmt.Printf("%s\n", output)
+		return
+	},
 }
 
 func init() {
-  rootCmd.AddCommand(exportCmd)
-  exportCmd.Flags().StringVar(&format, "format", "zeit", "Format to export, possible values: zeit, tyme")
-  exportCmd.Flags().StringVar(&since, "since", "", "Date/time to start the export from")
-  exportCmd.Flags().StringVar(&until, "until", "", "Date/time to export until")
-  exportCmd.Flags().StringVarP(&project, "project", "p", "", "Project to be exported")
-  exportCmd.Flags().StringVarP(&task, "task", "t", "", "Task to be exported")
-
-  var err error
-  database, err = InitDatabase()
-  if err != nil {
-    fmt.Printf("%s %+v\n", CharError, err)
-    os.Exit(1)
-  }
+	rootCmd.AddCommand(exportCmd)
+	exportCmd.Flags().StringVar(&format, "format", "zeit", "Format to export, possible values: zeit, tyme")
+	exportCmd.Flags().StringVar(&since, "since", "", "Date/time to start the export from")
+	exportCmd.Flags().StringVar(&until, "until", "", "Date/time to export until")
+	exportCmd.Flags().StringVarP(&project, "project", "p", "", "Project to be exported")
+	exportCmd.Flags().StringVarP(&task, "task", "t", "", "Task to be exported")
+	exportCmd.Flags().BoolVar(&exportDate, "date", false, "Add the 'date' field to the export")
+	exportCmd.Flags().BoolVar(&exportHours, "hours-decimal", false, "Add an 'hours' field calculated with '--decimal' to the export")
+	var err error
+	database, err = InitDatabase()
+	if err != nil {
+		fmt.Printf("%s %+v\n", CharError, err)
+		os.Exit(1)
+	}
 }

--- a/z/rootCmd.go
+++ b/z/rootCmd.go
@@ -1,10 +1,11 @@
 package z
 
 import (
-  "fmt"
-  "github.com/spf13/cobra"
-  "github.com/gookit/color"
-  "os"
+	"fmt"
+	"os"
+
+	"github.com/gookit/color"
+	"github.com/spf13/cobra"
 )
 
 var database *Database
@@ -23,36 +24,36 @@ var force bool
 
 var noColors bool
 
-const(
-  CharTrack = " ▶"
-  CharFinish = " ■"
-  CharErase = " ◀"
-  CharError = " ▲"
-  CharInfo = " ●"
-  CharMore = " ◆"
+const (
+	CharTrack  = " ▶"
+	CharFinish = " ■"
+	CharErase  = " ◀"
+	CharError  = " ▲"
+	CharInfo   = " ●"
+	CharMore   = " ◆"
 )
 
 var rootCmd = &cobra.Command{
-  Use:   "zeit",
-  Short: "Command line Zeiterfassung",
-  Long:  `A command line time tracker.`,
+	Use:   "zeit",
+	Short: "Command line Zeiterfassung",
+	Long:  `A command line time tracker.`,
 }
 
 func Execute() {
-  if err := rootCmd.Execute(); err != nil {
-    fmt.Printf("%s %+v\n", CharError, err)
-    os.Exit(-1)
-  }
+	if err := rootCmd.Execute(); err != nil {
+		fmt.Printf("%s %+v\n", CharError, err)
+		os.Exit(-1)
+	}
 }
 
 func init() {
-  cobra.OnInitialize(initConfig)
+	cobra.OnInitialize(initConfig)
 
-  rootCmd.PersistentFlags().BoolVar(&noColors, "no-colors", false, "Do not use colors in output")
+	rootCmd.PersistentFlags().BoolVar(&noColors, "no-colors", false, "Do not use colors in output")
 }
 
 func initConfig() {
-  if noColors == true {
-    color.Disable()
-  }
+	if noColors == true {
+		color.Disable()
+	}
 }

--- a/z/tyme.go
+++ b/z/tyme.go
@@ -1,88 +1,89 @@
 package z
 
 import (
-  "encoding/json"
-  // "fmt"
-  "os"
-  "github.com/shopspring/decimal"
-  "time"
+	"encoding/json"
+	// "fmt"
+	"os"
+	"time"
+
+	"github.com/shopspring/decimal"
 )
 
 type TymeEntry struct {
-  Billing string `json:"billing"` // "UNBILLED",
-  Category string `json:"category"` // "Client",
-  Distance string `json:"distance"` // "0",
-  Duration string `json:"duration"` // "15",
-  Start string `json:"start"` // "2020-09-01T08:45:00+01:00",
-  End string `json:"end"` // "2020-09-01T08:57:00+01:00",
-  Note string `json:"note"` // "",
-  Project string `json:"project"` // "Project",
-  Quantity string `json:"quantity"` // "0",
-  Rate string `json:"rate"` // "140",
-  RoundingMethod string `json:"rounding_method"` // "NEAREST",
-  RoundingMinutes int `json:"rounding_minutes"` // 15,
-  Subtask string `json:"subtask"` // "",
-  Sum string `json:"sum"` // "35",
-  Task string `json:"task"` // "Development",
-  Type string `json:"type"` // "timed",
-  User string `json:"user"` // ""
+	Billing         string `json:"billing"`          // "UNBILLED",
+	Category        string `json:"category"`         // "Client",
+	Distance        string `json:"distance"`         // "0",
+	Duration        string `json:"duration"`         // "15",
+	Start           string `json:"start"`            // "2020-09-01T08:45:00+01:00",
+	End             string `json:"end"`              // "2020-09-01T08:57:00+01:00",
+	Note            string `json:"note"`             // "",
+	Project         string `json:"project"`          // "Project",
+	Quantity        string `json:"quantity"`         // "0",
+	Rate            string `json:"rate"`             // "140",
+	RoundingMethod  string `json:"rounding_method"`  // "NEAREST",
+	RoundingMinutes int    `json:"rounding_minutes"` // 15,
+	Subtask         string `json:"subtask"`          // "",
+	Sum             string `json:"sum"`              // "35",
+	Task            string `json:"task"`             // "Development",
+	Type            string `json:"type"`             // "timed",
+	User            string `json:"user"`             // ""
 }
 
 type Tyme struct {
-  Data []TymeEntry `json:"data"`
+	Data []TymeEntry `json:"data"`
 }
 
 func (tyme *Tyme) Load(filename string) error {
-  file, err := os.Open(filename)
-  if err != nil {
-    return err
-  }
-  defer file.Close()
+	file, err := os.Open(filename)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
 
-  decoder := json.NewDecoder(file)
+	decoder := json.NewDecoder(file)
 
-  if err = decoder.Decode(&tyme); err != nil {
-    return err
-  }
+	if err = decoder.Decode(&tyme); err != nil {
+		return err
+	}
 
-  return nil
+	return nil
 }
 
 func (tyme *Tyme) FromEntries(entries []Entry) error {
-  for _, entry := range entries {
-    duration := decimal.NewFromFloat(entry.Finish.Sub(entry.Begin).Minutes())
+	for _, entry := range entries {
+		duration := decimal.NewFromFloat(entry.Finish.Sub(entry.Begin).Minutes())
 
-    tymeEntry := TymeEntry{
-      Billing: "UNBILLED",
-      Category: "",
-      Distance: "0",
-      Duration: duration.StringFixed(0),
-      Start: entry.Begin.Format(time.RFC3339),
-      End: entry.Finish.Format(time.RFC3339),
-      Note: entry.Notes,
-      Project: entry.Project,
-      Quantity: "0",
-      Rate: "0",
-      RoundingMethod: "NEAREST",
-      RoundingMinutes: 15,
-      Subtask: "",
-      Sum: "0",
-      Task: entry.Task,
-      Type: "timed",
-      User: "",
-    }
+		tymeEntry := TymeEntry{
+			Billing:         "UNBILLED",
+			Category:        "",
+			Distance:        "0",
+			Duration:        duration.StringFixed(0),
+			Start:           entry.Begin.Format(time.RFC3339),
+			End:             entry.Finish.Format(time.RFC3339),
+			Note:            entry.Notes,
+			Project:         entry.Project,
+			Quantity:        "0",
+			Rate:            "0",
+			RoundingMethod:  "NEAREST",
+			RoundingMinutes: 15,
+			Subtask:         "",
+			Sum:             "0",
+			Task:            entry.Task,
+			Type:            "timed",
+			User:            "",
+		}
 
-    tyme.Data = append(tyme.Data, tymeEntry)
-  }
+		tyme.Data = append(tyme.Data, tymeEntry)
+	}
 
-  return nil
+	return nil
 }
 
 func (tyme *Tyme) Stringify() string {
-  stringified, err := json.Marshal(tyme)
-  if err != nil {
-    return ""
-  }
+	stringified, err := json.Marshal(tyme)
+	if err != nil {
+		return ""
+	}
 
-  return string(stringified)
+	return string(stringified)
 }


### PR DESCRIPTION
2nd attempt at the PR. Comment from old one: 

Added both hours and date to both export types.
Choose the 'string' datatype as that makes it easiest to fit in the way the project is structured.

date -> 'DD-MM-YY' -> '03-04-2020' 
hours -> 3.45  # uses the 'fmtHours' function 
Both flags are optional and by default disabled.

Build successfully with 'make VERSION=0.0.8' and tested both outputs with the optional flags. -> Output as desired.

Let me know if any other changes are requiered or wanted, and I adapt as needed.

This should close https://github.com/mrusme/zeit/issues/32
