### PR TITLE
PR2: Making Time Parsing consistent between cmds, add more formats and set relative time in context

### DIFF
--- a/z/entry.go
+++ b/z/entry.go
@@ -37,12 +37,12 @@ func NewEntry(
   newEntry.Task = task
   newEntry.User = user
 
-  _, err = newEntry.SetBeginFromString(begin)
+  _, err = newEntry.SetBeginFromString(begin, time.Time{})
   if err != nil {
     return Entry{}, err
   }
 
-  _, err = newEntry.SetFinishFromString(finish)
+  _, err = newEntry.SetFinishFromString(finish, time.Time{})
   if err != nil {
     return Entry{}, err
   }
@@ -65,14 +65,14 @@ func (entry *Entry) SetIDFromDatabaseKey(key string) (error) {
   return nil
 }
 
-func (entry *Entry) SetBeginFromString(begin string) (time.Time, error) {
+func (entry *Entry) SetBeginFromString(begin string, contextTime time.Time) (time.Time, error) {
   var beginTime time.Time
   var err error
 
   if begin == "" {
     beginTime = time.Now()
   } else {
-    beginTime, err = ParseTime(begin)
+    beginTime, err = ParseTime(begin, contextTime)
     if err != nil {
       return beginTime, err
     }
@@ -82,12 +82,12 @@ func (entry *Entry) SetBeginFromString(begin string) (time.Time, error) {
   return beginTime, nil
 }
 
-func (entry *Entry) SetFinishFromString(finish string) (time.Time, error) {
+func (entry *Entry) SetFinishFromString(finish string, contextTime time.Time) (time.Time, error) {
   var finishTime time.Time
   var err error
 
   if finish != "" {
-    finishTime, err = ParseTime(finish)
+    finishTime, err = ParseTime(finish, contextTime)
     if err != nil {
       return finishTime, err
     }

--- a/z/entryCmd.go
+++ b/z/entryCmd.go
@@ -25,7 +25,7 @@ var entryCmd = &cobra.Command{
 
     if begin != "" || finish != "" || project != "" || notes != "" || task != "" {
       if begin != "" {
-        entry.Begin, err = entry.SetBeginFromString(begin)
+        entry.Begin, err = entry.SetBeginFromString(begin, entry.Begin)
         if err != nil {
           fmt.Printf("%s %+v\n", CharError, err)
           os.Exit(1)
@@ -33,7 +33,7 @@ var entryCmd = &cobra.Command{
       }
 
       if finish != "" {
-        entry.Finish, err = entry.SetFinishFromString(finish)
+        entry.Finish, err = entry.SetFinishFromString(finish, entry.Finish)
         if err != nil {
           fmt.Printf("%s %+v\n", CharError, err)
           os.Exit(1)

--- a/z/entryCmd.go
+++ b/z/entryCmd.go
@@ -5,7 +5,6 @@ import (
   "os"
   "strings"
 
-  "github.com/araddon/dateparse"
   "github.com/spf13/cobra"
 )
 
@@ -26,7 +25,7 @@ var entryCmd = &cobra.Command{
 
     if begin != "" || finish != "" || project != "" || notes != "" || task != "" {
       if begin != "" {
-        entry.Begin, err = dateparse.ParseAny(begin)
+        entry.Begin, err = entry.SetBeginFromString(begin)
         if err != nil {
           fmt.Printf("%s %+v\n", CharError, err)
           os.Exit(1)
@@ -34,7 +33,7 @@ var entryCmd = &cobra.Command{
       }
 
       if finish != "" {
-        entry.Finish, err = dateparse.ParseAny(finish)
+        entry.Finish, err = entry.SetFinishFromString(finish)
         if err != nil {
           fmt.Printf("%s %+v\n", CharError, err)
           os.Exit(1)

--- a/z/helpers.go
+++ b/z/helpers.go
@@ -10,6 +10,8 @@ import (
   "time"
   "math"
   "errors"
+
+  "github.com/araddon/dateparse"
 )
 
 
@@ -105,7 +107,20 @@ func ParseTime(timeStr string) (time.Time, error) {
   case TFRelHourMinute, TFRelHourFraction:
     return RelToTime(timeStr, tfId)
   default:
-    return time.Now(), errors.New("could not match passed time")
+    loc, err := time.LoadLocation("Local")
+
+    if err != nil {
+      return time.Now(), errors.New("could not load location")
+    }
+
+    time.Local = loc
+
+    tnew, err := dateparse.ParseIn(timeStr, loc)
+    if err != nil {
+      return time.Now(), errors.New("could not match passed time")
+    }
+
+    return tnew, nil
   }
 }
 

--- a/z/helpers.go
+++ b/z/helpers.go
@@ -12,6 +12,7 @@ import (
   "errors"
 
   "github.com/araddon/dateparse"
+  "github.com/spf13/viper"
 )
 
 
@@ -59,7 +60,7 @@ func GetTimeFormat(timeStr string) (int) {
 }
 
 // TODO: Use https://golang.org/pkg/time/#ParseDuration
-func RelToTime(timeStr string, ftId int) (time.Time, error) {
+func RelToTime(timeStr string, ftId int, contextTime time.Time) (time.Time, error) {
     var re = regexp.MustCompile(TimeFormats()[ftId])
     gm := re.FindStringSubmatch(timeStr)
 
@@ -80,6 +81,17 @@ func RelToTime(timeStr string, ftId int) (time.Time, error) {
 
     var t time.Time
 
+    if viper.IsSet("time.relative") && viper.GetString("time.relative") == "context" && !contextTime.IsZero() {
+      switch gm[1] {
+      case "+":
+        t = contextTime.Add(time.Hour * time.Duration(hours) + time.Minute * time.Duration(minutes))
+      case "-":
+        t = contextTime.Add((time.Hour * time.Duration(hours) + time.Minute * time.Duration(minutes)) * -1)
+      }
+
+      return t, nil
+    }
+
     switch gm[1] {
     case "+":
       t = time.Now().Local().Add(time.Hour * time.Duration(hours) + time.Minute * time.Duration(minutes))
@@ -90,7 +102,7 @@ func RelToTime(timeStr string, ftId int) (time.Time, error) {
     return t, nil
 }
 
-func ParseTime(timeStr string) (time.Time, error) {
+func ParseTime(timeStr string, contextTime time.Time) (time.Time, error) {
   tfId := GetTimeFormat(timeStr)
 
   t:= time.Now()
@@ -105,7 +117,7 @@ func ParseTime(timeStr string) (time.Time, error) {
     tnew := time.Date(t.Year(), t.Month(), t.Day(), tadj.Hour(), tadj.Minute(), t.Second(), t.Nanosecond(), t.Location())
     return tnew, err
   case TFRelHourMinute, TFRelHourFraction:
-    return RelToTime(timeStr, tfId)
+    return RelToTime(timeStr, tfId, contextTime)
   default:
     loc, err := time.LoadLocation("Local")
 


### PR DESCRIPTION
### Time parsing

Changes are shown by track cmd, but same applys for entry as well, so Time parsing is consistent between both cmds now and supports all kinds of format. I believe that could fix Issue-29

#### before change
```
go run . track -p "TESTS" -t "Zeit-Test" -b '10:00' -s '11:00'
▶ tracked Zeit-Test on TESTS
go run . track -p "TESTS" -t "Zeit-Test" -b '01:00pm' -s '02:00pm'
▶ tracked Zeit-Test on TESTS
go run . track -p "TESTS" -t "Zeit-Test" -b '-04:00' -s '-03:00'
▶ tracked Zeit-Test on TESTS
go run . track -p "TESTS" -t "Zeit-Test" -b '-02:00' -s '+01:00'
▶ tracked Zeit-Test on TESTS
go run . track -p "TESTS" -t "Zeit-Test" -b '2023-09-11 10:00 +0300' -s '2023-09-11 12:00 +0400'
▲ could not match passed time
exit status 1
go run . track -p "TESTS" -t "Zeit-Test" -b '2023-09-11 20:00' -s '2023-09-11 21:00'
▲ could not match passed time
exit status 1
go run . track -p "TESTS" -t "Zeit-Test" -b '2023-09-11T20:00' -s '2023-09-11T21:00'
▲ could not match passed time
exit status 1
go run . track -p "TESTS" -t "Zeit-Test" -b '2023-09-11T20:00:00' -s '2023-09-11T21:00:00'
▲ could not match passed time
exit status 1
go run . track -p "TESTS" -t "Zeit-Test" -b '2023-09-11T20:00:00+02:00' -s '2023-09-11T21:00:00+02:00'
▲ could not match passed time
exit status 1
```
#### after change

```
go run . track -p "TESTS" -t "Zeit-Test" -b '10:00' -s '11:00'
▶ tracked Zeit-Test on TESTS
go run . track -p "TESTS" -t "Zeit-Test" -b '01:00pm' -s '02:00pm'
▶ tracked Zeit-Test on TESTS
go run . track -p "TESTS" -t "Zeit-Test" -b '-04:00' -s '-03:00'
▶ tracked Zeit-Test on TESTS
go run . track -p "TESTS" -t "Zeit-Test" -b '-02:00' -s '+01:00'
▶ tracked Zeit-Test on TESTS
go run . track -p "TESTS" -t "Zeit-Test" -b '2023-09-11 10:00 +0300' -s '2023-09-11 12:00 +0400'
▶ tracked Zeit-Test on TESTS
go run . track -p "TESTS" -t "Zeit-Test" -b '2023-09-11 20:00' -s '2023-09-11 21:00'
▶ tracked Zeit-Test on TESTS
go run . track -p "TESTS" -t "Zeit-Test" -b '2023-09-11T20:00' -s '2023-09-11T21:00'
▶ tracked Zeit-Test on TESTS
go run . track -p "TESTS" -t "Zeit-Test" -b '2023-09-11T20:00:00' -s '2023-09-11T21:00:00'
▶ tracked Zeit-Test on TESTS
go run . track -p "TESTS" -t "Zeit-Test" -b '2023-09-11T20:00:00+02:00' -s '2023-09-11T21:00:00+02:00'
▶ tracked Zeit-Test on TESTS
```

### Relative time

Relative Times always referred to time.Now(), so if you want to change an entry from the past in relative manner this was not possible. Now you can activate context-based relative times via config-file, which will apply the difference on an given point in time if it exists. In other words, if you use relative Times in track it will calculate from time.Now() as always, but if you apply a relative time with 'zeit entry' on an existing entry it will calculate from this time. If parameter in config is not set it will also use time.Now() as it is.

````
time:
  relative: context
````

#### Example with 'relative: now' 

```
 go run . track -p ZEIT_TESTS -t Relative-Test-Context-1 -b "2025-02-01 10:00" -s "2025-02-01 12:00"
 go run . list
 9ae726fc-5ff5-4112-ac1e-840d30e5b441 Relative-Test-Context-1 on ZEIT_TESTS from 2025-02-01 10:00 +0100 to 2025-02-01 12:00 +0100 (2:00h)
 go run . entry -b "+01:00" 9ae726fc-5ff5-4112-ac1e-840d30e5b441
 go run . list
 9ae726fc-5ff5-4112-ac1e-840d30e5b441 Relative-Test-Context-1 on ZEIT_TESTS from 2025-02-09 11:25 +0100 to 2025-02-01 12:00 +0100 (-192:34h)

```
So I wanted to reduce the already book task by 1 hour but got 194 minus hours. 

#### Example with 'relative: context' 

```
 go run . track -p ZEIT_TESTS -t Relative-Test-Context-2 -b "2025-02-01 10:00" -s "2025-02-01 12:00"
 b8276946-1c06-490e-b6b8-c9628479c6ed Relative-Test-Context-2 on ZEIT_TESTS from 2025-02-01 10:00 +0100 to 2025-02-01 12:00 +0100 (2:00h)
 9ae726fc-5ff5-4112-ac1e-840d30e5b441 Relative-Test-Context-1 on ZEIT_TESTS from 2025-02-09 11:25 +0100 to 2025-02-01 12:00 +0100 (-192:34h)
 go run . entry -b "+01:00" b8276946-1c06-490e-b6b8-c9628479c6ed
 go run . list
 b8276946-1c06-490e-b6b8-c9628479c6ed Relative-Test-Context-2 on ZEIT_TESTS from 2025-02-01 11:00 +0100 to 2025-02-01 12:00 +0100 (1:00h)
 ae726fc-5ff5-4112-ac1e-840d30e5b441 Relative-Test-Context-1 on ZEIT_TESTS from 2025-02-09 11:25 +0100 to 2025-02-01 12:00 +0100 (-192:34h)

```

For 'time track' relative still works on now() 

```
 go run . track -p ZEIT_TESTS -t Relative-Test-Context-3 -b "-01:00"
 go run . list
 b8276946-1c06-490e-b6b8-c9628479c6ed Relative-Test-Context-2 on ZEIT_TESTS from 2025-02-01 11:00 +0100 to 2025-02-01 12:00 +0100 (1:00h)
 4b78d93f-1265-41cb-85c8-d129798a52c3 Relative-Test-Context-3 on ZEIT_TESTS from 2025-02-09 09:29 +0100 to 2025-02-09 10:29 +0100 (1:00h) [running]
 9ae726fc-5ff5-4112-ac1e-840d30e5b441 Relative-Test-Context-1 on ZEIT_TESTS from 2025-02-09 11:25 +0100 to 2025-02-01 12:00 +0100 (-192:34h)
```