### PR TITLE
PR3: Add some options and refactor shared functions

### DIFF
--- a/z/constants.go
+++ b/z/constants.go
@@ -5,3 +5,15 @@ const (
   FlagDebug    string = "debug"
 )
 
+const (
+  TFAbsTwelveHour     int = 0
+  TFAbsTwentyfourHour int = 1
+  TFRelHourMinute     int = 2
+  TFRelHourFraction   int = 3
+)
+
+const (
+  FinishWithMetadata int = 0
+  FinishOnlyTime     int = 1
+)
+

--- a/z/entry.go
+++ b/z/entry.go
@@ -7,6 +7,7 @@ import (
   "fmt"
   "github.com/gookit/color"
   "github.com/shopspring/decimal"
+  "github.com/spf13/viper"
 )
 
 type Entry struct {
@@ -79,7 +80,8 @@ func (entry *Entry) SetBeginFromString(begin string, contextTime time.Time) (tim
   }
 
   entry.Begin = beginTime
-  return beginTime, nil
+  entry.secondsBegin()
+  return entry.Begin, nil
 }
 
 func (entry *Entry) SetFinishFromString(finish string, contextTime time.Time) (time.Time, error) {
@@ -94,11 +96,12 @@ func (entry *Entry) SetFinishFromString(finish string, contextTime time.Time) (t
   }
 
   entry.Finish = finishTime
-  return finishTime, nil
+  entry.secondsFinish()
+  return entry.Finish, nil
 }
 
 func (entry *Entry) IsFinishedAfterBegan() (bool) {
-  return (entry.Finish.IsZero() || entry.Begin.Before(entry.Finish))
+  return (entry.Finish.IsZero() || entry.Begin.Before(entry.Finish) || entry.Begin.Equal(entry.Finish))
 }
 
 func (entry *Entry) GetOutputForTrack(isRunning bool, wasRunning bool) (string) {
@@ -222,3 +225,16 @@ func GetFilteredEntries(entries []Entry, project string, task string, since time
 
   return filteredEntries, nil
 }
+
+func (entry *Entry) secondsBegin() {
+  if viper.GetBool("time.no-seconds") {
+    entry.Begin = entry.Begin.Truncate(time.Duration(time.Minute))
+  }
+}
+
+func (entry *Entry) secondsFinish() {
+  if viper.GetBool("time.no-seconds") {
+    entry.Finish = entry.Finish.Truncate(time.Duration(time.Minute))
+  }
+}
+

--- a/z/entryCmd.go
+++ b/z/entryCmd.go
@@ -72,4 +72,12 @@ func init() {
   entryCmd.Flags().StringVarP(&notes, "notes", "n", "", "Update activity notes")
   entryCmd.Flags().StringVarP(&task, "task", "t", "", "Update activity task")
   entryCmd.Flags().BoolVar(&fractional, "decimal", false, "Show fractional hours in decimal format instead of minutes")
+
+  flagName := "task"
+  entryCmd.RegisterFlagCompletionFunc(flagName, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+    user := GetCurrentUser()
+    entries, _ := database.ListEntries(user)
+    _, tasks := listProjectsAndTasks(entries)
+    return tasks, cobra.ShellCompDirectiveDefault
+  })
 }

--- a/z/exportCmd.go
+++ b/z/exportCmd.go
@@ -3,9 +3,7 @@ package z
 import (
   "os"
   "fmt"
-  "time"
   "encoding/json"
-  "github.com/jinzhu/now"
   "github.com/spf13/cobra"
 )
 
@@ -44,25 +42,7 @@ var exportCmd = &cobra.Command{
       fmt.Printf("%s %+v\n", CharError, err)
       os.Exit(1)
     }
-
-    var sinceTime time.Time
-    var untilTime time.Time
-
-    if since != "" {
-      sinceTime, err = now.Parse(since)
-      if err != nil {
-        fmt.Printf("%s %+v\n", CharError, err)
-        os.Exit(1)
-      }
-    }
-
-    if until != "" {
-      untilTime, err = now.Parse(until)
-      if err != nil {
-        fmt.Printf("%s %+v\n", CharError, err)
-        os.Exit(1)
-      }
-    }
+    sinceTime, untilTime := ParseSinceUntil(since, until, listRange)
 
     var filteredEntries []Entry
     filteredEntries, err = GetFilteredEntries(entries, project, task, sinceTime, untilTime)
@@ -100,6 +80,7 @@ func init() {
   exportCmd.Flags().StringVar(&format, "format", "zeit", "Format to export, possible values: zeit, tyme")
   exportCmd.Flags().StringVar(&since, "since", "", "Date/time to start the export from")
   exportCmd.Flags().StringVar(&until, "until", "", "Date/time to export until")
+  exportCmd.Flags().StringVar(&listRange, "range", "", "shortcut to set since/until for a given range (today, yesterday, thisWeek, lastWeek, thisMonth, lastMonth)")
   exportCmd.Flags().StringVarP(&project, "project", "p", "", "Project to be exported")
   exportCmd.Flags().StringVarP(&task, "task", "t", "", "Task to be exported")
 }

--- a/z/exportCmd.go
+++ b/z/exportCmd.go
@@ -83,4 +83,12 @@ func init() {
   exportCmd.Flags().StringVar(&listRange, "range", "", "shortcut to set since/until for a given range (today, yesterday, thisWeek, lastWeek, thisMonth, lastMonth)")
   exportCmd.Flags().StringVarP(&project, "project", "p", "", "Project to be exported")
   exportCmd.Flags().StringVarP(&task, "task", "t", "", "Task to be exported")
+
+  flagName := "task"
+  exportCmd.RegisterFlagCompletionFunc(flagName, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+    user := GetCurrentUser()
+    entries, _ := database.ListEntries(user)
+    _, tasks := listProjectsAndTasks(entries)
+    return tasks, cobra.ShellCompDirectiveDefault
+  })
 }

--- a/z/exportCmd.go
+++ b/z/exportCmd.go
@@ -3,6 +3,7 @@ package z
 import (
   "os"
   "fmt"
+  "strings"
   "encoding/json"
   "github.com/spf13/cobra"
 )
@@ -80,7 +81,7 @@ func init() {
   exportCmd.Flags().StringVar(&format, "format", "zeit", "Format to export, possible values: zeit, tyme")
   exportCmd.Flags().StringVar(&since, "since", "", "Date/time to start the export from")
   exportCmd.Flags().StringVar(&until, "until", "", "Date/time to export until")
-  exportCmd.Flags().StringVar(&listRange, "range", "", "shortcut to set since/until for a given range (today, yesterday, thisWeek, lastWeek, thisMonth, lastMonth)")
+  exportCmd.Flags().StringVar(&listRange, "range", "", "Shortcut for --since and --until that accepts: " + strings.Join(Ranges(), ", "))
   exportCmd.Flags().StringVarP(&project, "project", "p", "", "Project to be exported")
   exportCmd.Flags().StringVarP(&task, "task", "t", "", "Task to be exported")
 

--- a/z/finishCmd.go
+++ b/z/finishCmd.go
@@ -45,6 +45,7 @@ var finishCmd = &cobra.Command{
       runningEntry.Finish = tmpEntry.Finish
     } else {
       runningEntry.Finish = time.Now()
+      runningEntry.secondsFinish()
     }
 
     if project != "" {

--- a/z/finishCmd.go
+++ b/z/finishCmd.go
@@ -1,9 +1,6 @@
 package z
 
 import (
-  "os"
-  "fmt"
-  "time"
   "github.com/spf13/cobra"
 )
 
@@ -12,89 +9,7 @@ var finishCmd = &cobra.Command{
   Short: "Finish currently running activity",
   Long: "Finishing tracking of currently running activity.",
   Run: func(cmd *cobra.Command, args []string) {
-    user := GetCurrentUser()
-
-    runningEntryId, err := database.GetRunningEntryId(user)
-    if err != nil {
-      fmt.Printf("%s %+v\n", CharError, err)
-      os.Exit(1)
-    }
-
-    if runningEntryId == "" {
-      fmt.Printf("%s not running\n", CharFinish)
-      os.Exit(1)
-    }
-
-    runningEntry, err := database.GetEntry(user, runningEntryId)
-    if err != nil {
-      fmt.Printf("%s %+v\n", CharError, err)
-      os.Exit(1)
-    }
-
-    tmpEntry, err := NewEntry(runningEntry.ID, begin, finish, project, task, user)
-    if err != nil {
-      fmt.Printf("%s %+v\n", CharError, err)
-      os.Exit(1)
-    }
-
-    if begin != "" {
-      runningEntry.Begin = tmpEntry.Begin
-    }
-
-    if finish != "" {
-      runningEntry.Finish = tmpEntry.Finish
-    } else {
-      runningEntry.Finish = time.Now()
-      runningEntry.secondsFinish()
-    }
-
-    if project != "" {
-      runningEntry.Project = tmpEntry.Project
-    }
-
-    if task != "" {
-      runningEntry.Task = tmpEntry.Task
-    }
-
-    if notes != "" {
-      runningEntry.Notes = fmt.Sprintf("%s\n%s", runningEntry.Notes, notes)
-    }
-
-    if runningEntry.Task != "" {
-      task, err := database.GetTask(user, runningEntry.Task)
-      if err != nil {
-        fmt.Printf("%s %+v\n", CharError, err)
-        os.Exit(1)
-      }
-
-      if task.GitRepository != "" && task.GitRepository != "-" {
-        stdout, stderr, err := GetGitLog(task.GitRepository, runningEntry.Begin, runningEntry.Finish)
-        if err != nil {
-          fmt.Printf("%s %+v\n", CharError, err)
-          os.Exit(1)
-        }
-
-        if stderr == "" {
-          runningEntry.Notes = fmt.Sprintf("%s\n%s", runningEntry.Notes, stdout)
-        } else {
-          fmt.Printf("%s notes were not imported: %+v\n", CharError, stderr)
-        }
-      }
-    }
-
-    if runningEntry.IsFinishedAfterBegan() == false {
-      fmt.Printf("%s %+v\n", CharError, "beginning time of tracking cannot be after finish time")
-      os.Exit(1)
-    }
-
-    _, err = database.FinishEntry(user, runningEntry)
-    if err != nil {
-      fmt.Printf("%s %+v\n", CharError, err)
-      os.Exit(1)
-    }
-
-    fmt.Printf(runningEntry.GetOutputForFinish())
-    return
+    finishTask(FinishWithMetadata)
   },
 }
 

--- a/z/finishCmd.go
+++ b/z/finishCmd.go
@@ -105,4 +105,12 @@ func init() {
   finishCmd.Flags().StringVarP(&project, "project", "p", "", "Project to be assigned")
   finishCmd.Flags().StringVarP(&notes, "notes", "n", "", "Activity notes")
   finishCmd.Flags().StringVarP(&task, "task", "t", "", "Task to be assigned")
+
+  flagName := "task"
+  finishCmd.RegisterFlagCompletionFunc(flagName, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+    user := GetCurrentUser()
+    entries, _ := database.ListEntries(user)
+    _, tasks := listProjectsAndTasks(entries)
+    return tasks, cobra.ShellCompDirectiveDefault
+  })
 }

--- a/z/helpers.go
+++ b/z/helpers.go
@@ -10,9 +10,12 @@ import (
   "time"
   "math"
   "errors"
+  "fmt"
+  "os"
 
   "github.com/araddon/dateparse"
   "github.com/spf13/viper"
+  "github.com/jinzhu/now"
 )
 
 
@@ -193,3 +196,67 @@ func GetGitLog(repo string, since time.Time, until time.Time) (string, string, e
   return stdoutStr, stderrStr, nil
 }
 
+
+func ParseSinceUntil(since string, until string, listRange string) (time.Time, time.Time) {
+
+  var sinceTime time.Time
+  var untilTime time.Time
+  var err error
+
+  if since != "" {
+    sinceTime, err = now.Parse(since)
+    if err != nil {
+      fmt.Printf("%s %+v\n", CharError, err)
+      os.Exit(1)
+    }
+  }
+
+  if until != "" {
+    untilTime, err = now.Parse(until)
+    if err != nil {
+      fmt.Printf("%s %+v\n", CharError, err)
+      os.Exit(1)
+    }
+  }
+
+  if listRange != "" {
+    if since != "" || until != "" {
+      fmt.Println("Range and since/until can't be used together, select one of them")
+      os.Exit(1)
+    }
+
+    if viper.GetBool("firstWeekDayMonday") {
+      now.WeekStartDay = time.Monday
+    }
+
+    loc, _ := time.LoadLocation("Local")
+    time.Local = loc
+    switch listRange {
+    case "today":
+      sinceTime = now.BeginningOfDay()
+      untilTime = now.EndOfDay()
+    case "yesterday":
+      sinceTime = now.BeginningOfDay().AddDate(0, 0, -1)
+      untilTime = now.EndOfDay().AddDate(0, 0, -1)
+    case "thisWeek":
+      sinceTime = now.BeginningOfWeek()
+      untilTime = now.EndOfWeek()
+    case "lastWeek":
+      lastWeekDay := time.Now().AddDate(0, 0, -7)
+      sinceTime = now.With(lastWeekDay).BeginningOfWeek()
+      untilTime = now.With(lastWeekDay).EndOfWeek()
+    case "thisMonth":
+      sinceTime = now.BeginningOfMonth()
+      untilTime = now.EndOfMonth()
+    case "lastMonth":
+      lastMonthDay := time.Now().AddDate(0, -1, 0)
+      sinceTime = now.With(lastMonthDay).BeginningOfMonth()
+      untilTime = now.With(lastMonthDay).EndOfMonth()
+    default:
+      fmt.Println("unkown range selection: (today, yesterday, thisWeek, lastWeek, thisMonth, lastMonth)")
+      os.Exit(1)
+    }
+  }
+
+  return sinceTime, untilTime
+}

--- a/z/helpers.go
+++ b/z/helpers.go
@@ -18,14 +18,6 @@ import (
   "github.com/jinzhu/now"
 )
 
-
-const (
-  TFAbsTwelveHour int = 0
-  TFAbsTwentyfourHour int = 1
-  TFRelHourMinute int = 2
-  TFRelHourFraction int = 3
-)
-
 func TimeFormats() []string {
   return []string{
     `^\d{1,2}:\d{1,2}(am|pm)$`, // Absolute twelve hour format

--- a/z/helpers.go
+++ b/z/helpers.go
@@ -188,6 +188,16 @@ func GetGitLog(repo string, since time.Time, until time.Time) (string, string, e
   return stdoutStr, stderrStr, nil
 }
 
+func Ranges() []string {
+  return []string{
+    "today",
+    "yesterday",
+    "thisWeek",
+    "lastWeek",
+    "thisMonth",
+    "lastMonth",
+  }
+}
 
 func ParseSinceUntil(since string, until string, listRange string) (time.Time, time.Time) {
 
@@ -223,29 +233,29 @@ func ParseSinceUntil(since string, until string, listRange string) (time.Time, t
 
     loc, _ := time.LoadLocation("Local")
     time.Local = loc
-    switch listRange {
+    switch strings.ToLower(listRange) {
     case "today":
       sinceTime = now.BeginningOfDay()
       untilTime = now.EndOfDay()
     case "yesterday":
       sinceTime = now.BeginningOfDay().AddDate(0, 0, -1)
       untilTime = now.EndOfDay().AddDate(0, 0, -1)
-    case "thisWeek":
+    case "thisweek":
       sinceTime = now.BeginningOfWeek()
       untilTime = now.EndOfWeek()
-    case "lastWeek":
+    case "lastweek":
       lastWeekDay := time.Now().AddDate(0, 0, -7)
       sinceTime = now.With(lastWeekDay).BeginningOfWeek()
       untilTime = now.With(lastWeekDay).EndOfWeek()
-    case "thisMonth":
+    case "thismonth":
       sinceTime = now.BeginningOfMonth()
       untilTime = now.EndOfMonth()
-    case "lastMonth":
+    case "lastmonth":
       lastMonthDay := time.Now().AddDate(0, -1, 0)
       sinceTime = now.With(lastMonthDay).BeginningOfMonth()
       untilTime = now.With(lastMonthDay).EndOfMonth()
     default:
-      fmt.Println("unkown range selection: (today, yesterday, thisWeek, lastWeek, thisMonth, lastMonth)")
+      fmt.Println("Unknown range selection, possible options: ", strings.Join(Ranges(), " "))
       os.Exit(1)
     }
   }

--- a/z/listCmd.go
+++ b/z/listCmd.go
@@ -2,6 +2,7 @@ package z
 
 import (
   "fmt"
+  "strings"
 
   "github.com/shopspring/decimal"
   "github.com/spf13/cobra"
@@ -38,7 +39,7 @@ func init() {
   rootCmd.AddCommand(listCmd)
   listCmd.Flags().StringVar(&since, "since", "", "Date/time to start the list from")
   listCmd.Flags().StringVar(&until, "until", "", "Date/time to list until")
-  listCmd.Flags().StringVar(&listRange, "range", "", "shortcut to set since/until for a given range (today, yesterday, thisWeek, lastWeek, thisMonth, lastMonth)")
+  listCmd.Flags().StringVar(&listRange, "range", "", "Shortcut for --since and --until that accepts: " + strings.Join(Ranges(), ", "))
   listCmd.Flags().StringVarP(&project, "project", "p", "", "Project to be listed")
   listCmd.Flags().StringVarP(&task, "task", "t", "", "Task to be listed")
   listCmd.Flags().BoolVar(&fractional, "decimal", false, "Show fractional hours in decimal format instead of minutes")

--- a/z/listCmd.go
+++ b/z/listCmd.go
@@ -3,9 +3,7 @@ package z
 import (
   "fmt"
   "os"
-  "time"
 
-  "github.com/jinzhu/now"
   "github.com/shopspring/decimal"
   "github.com/spf13/cobra"
 )
@@ -29,24 +27,7 @@ var listCmd = &cobra.Command{
       os.Exit(1)
     }
 
-    var sinceTime time.Time
-    var untilTime time.Time
-
-    if since != "" {
-      sinceTime, err = now.Parse(since)
-      if err != nil {
-        fmt.Printf("%s %+v\n", CharError, err)
-        os.Exit(1)
-      }
-    }
-
-    if until != "" {
-      untilTime, err = now.Parse(until)
-      if err != nil {
-        fmt.Printf("%s %+v\n", CharError, err)
-        os.Exit(1)
-      }
-    }
+    sinceTime, untilTime := ParseSinceUntil(since, until, listRange)
 
     var filteredEntries []Entry
     filteredEntries, err = GetFilteredEntries(entries, project, task, sinceTime, untilTime)
@@ -108,6 +89,7 @@ func init() {
   rootCmd.AddCommand(listCmd)
   listCmd.Flags().StringVar(&since, "since", "", "Date/time to start the list from")
   listCmd.Flags().StringVar(&until, "until", "", "Date/time to list until")
+  listCmd.Flags().StringVar(&listRange, "range", "", "shortcut to set since/until for a given range (today, yesterday, thisWeek, lastWeek, thisMonth, lastMonth)")
   listCmd.Flags().StringVarP(&project, "project", "p", "", "Project to be listed")
   listCmd.Flags().StringVarP(&task, "task", "t", "", "Task to be listed")
   listCmd.Flags().BoolVar(&fractional, "decimal", false, "Show fractional hours in decimal format instead of minutes")

--- a/z/rootCmd.go
+++ b/z/rootCmd.go
@@ -18,6 +18,7 @@ var notes string
 
 var since string
 var until string
+var listRange string
 
 var format string
 var force bool

--- a/z/task.go
+++ b/z/task.go
@@ -3,6 +3,9 @@ package z
 import (
   "fmt"
   "os"
+  "time"
+
+  "github.com/spf13/viper"
 )
 
 type Task struct {
@@ -77,4 +80,149 @@ func listProjectsAndTasks(entries []Entry) (map[string]map[string]bool, []string
   return projectsAndTasks, allTasks
 }
 
+func trackTask() {
+  user := GetCurrentUser()
+
+  runningEntryId, err := database.GetRunningEntryId(user)
+  if err != nil {
+    fmt.Printf("%s %+v\n", CharError, err)
+    os.Exit(1)
+  }
+
+  if runningEntryId != "" {
+    fmt.Printf("%s a task is already running\n", CharTrack)
+    os.Exit(1)
+  }
+
+  if project == "" && viper.GetString("project.default") != "" {
+    project = viper.GetString("project.default")
+  }
+
+  if project == "" && viper.GetBool("project.mandatory") {
+    fmt.Println("project is mandatory but missing")
+    os.Exit(1)
+  }
+
+  if task == "" && viper.GetBool("task.mandatory") {
+    fmt.Println("task is mandatory but missing")
+    os.Exit(1)
+  }
+
+  newEntry, err := NewEntry("", begin, finish, project, task, user)
+  if err != nil {
+      fmt.Printf("%s %+v\n", CharError, err)
+      os.Exit(1)
+  }
+
+  if notes != "" {
+    newEntry.Notes = notes
+  }
+
+  isRunning := newEntry.Finish.IsZero()
+
+  _, err = database.AddEntry(user, newEntry, isRunning)
+  if err != nil {
+      fmt.Printf("%s %+v\n", CharError, err)
+      os.Exit(1)
+  }
+
+  fmt.Print(newEntry.GetOutputForTrack(isRunning, false))
+}
+
+func finishTask(mode int) {
+
+  user := GetCurrentUser()
+
+  runningEntryId, err := database.GetRunningEntryId(user)
+  if err != nil {
+    fmt.Printf("%s %+v\n", CharError, err)
+    os.Exit(1)
+  }
+
+  if runningEntryId == "" {
+    fmt.Printf("%s not running\n", CharFinish)
+    os.Exit(1)
+  }
+
+  runningEntry, err := database.GetEntry(user, runningEntryId)
+  if err != nil {
+    fmt.Printf("%s %+v\n", CharError, err)
+    os.Exit(1)
+  }
+
+  tmpEntry, err := NewEntry(runningEntry.ID, begin, finish, project, task, user)
+  if err != nil {
+    fmt.Printf("%s %+v\n", CharError, err)
+    os.Exit(1)
+  }
+
+  if begin != "" {
+    runningEntry.Begin = tmpEntry.Begin
+  }
+
+  if finish != "" {
+    runningEntry.Finish = tmpEntry.Finish
+  } else {
+    runningEntry.Finish = time.Now()
+  }
+
+  if mode == FinishWithMetadata {
+    finishTaskMetadata(user, &runningEntry, &tmpEntry)
+  }
+
+  if !runningEntry.IsFinishedAfterBegan() {
+    fmt.Printf("%s %+v\n", CharError, "beginning time of tracking cannot be after finish time")
+    os.Exit(1)
+  }
+
+  _, err = database.FinishEntry(user, runningEntry)
+  if err != nil {
+    fmt.Printf("%s %+v\n", CharError, err)
+    os.Exit(1)
+  }
+
+  fmt.Print(runningEntry.GetOutputForFinish())
+}
+
+func finishTaskMetadata(user string, runningEntry *Entry, tmpEntry *Entry) {
+
+  if project != "" {
+    runningEntry.Project = tmpEntry.Project
+  }
+
+  if task != "" {
+    runningEntry.Task = tmpEntry.Task
+  }
+
+  if notes != "" {
+    runningEntry.Notes = fmt.Sprintf("%s\n%s", runningEntry.Notes, notes)
+  }
+
+  if runningEntry.Task != "" {
+    task, err := database.GetTask(user, runningEntry.Task)
+    if err != nil {
+      fmt.Printf("%s %+v\n", CharError, err)
+      os.Exit(1)
+    }
+
+    taskGit(&task, runningEntry)
+  }
+
+}
+
+func taskGit(task *Task, runningEntry *Entry) {
+  if task.GitRepository != "" && task.GitRepository != "-" {
+    stdout, stderr, err := GetGitLog(task.GitRepository, runningEntry.Begin, runningEntry.Finish)
+    if err != nil {
+      fmt.Printf("%s %+v\n", CharError, err)
+      os.Exit(1)
+    }
+
+    if stderr == "" {
+      runningEntry.Notes = fmt.Sprintf("%s\n%s", runningEntry.Notes, stdout)
+    } else {
+      fmt.Printf("%s notes were not imported: %+v\n", CharError, stderr)
+    }
+  }
+}
 

--- a/z/task.go
+++ b/z/task.go
@@ -1,9 +1,80 @@
 package z
 
 import (
+  "fmt"
+  "os"
 )
 
 type Task struct {
   Name          string      `json:"name,omitempty"`
   GitRepository string      `json:"gitRepository,omitempty"`
 }
+
+func listEntries() []Entry {
+  user := GetCurrentUser()
+
+  entries, err := database.ListEntries(user)
+  if err != nil {
+    fmt.Printf("%s %+v\n", CharError, err)
+    os.Exit(1)
+  }
+
+  sinceTime, untilTime := ParseSinceUntil(since, until, listRange)
+
+  var filteredEntries []Entry
+  filteredEntries, err = GetFilteredEntries(entries, project, task, sinceTime, untilTime)
+  if err != nil {
+    fmt.Printf("%s %+v\n", CharError, err)
+    os.Exit(1)
+  }
+
+  if listOnlyProjectsAndTasks || listOnlyTasks {
+    printProjects(filteredEntries)
+    return nil
+  }
+  return filteredEntries
+}
+
+func printProjects(entries []Entry) {
+
+  projectsAndTasks, _ := listProjectsAndTasks(entries)
+  for project := range projectsAndTasks {
+    if listOnlyProjectsAndTasks && !listOnlyTasks {
+      fmt.Printf("%s %s\n", CharMore, project)
+    }
+
+    for task := range projectsAndTasks[project] {
+      if listOnlyProjectsAndTasks && !listOnlyTasks {
+        fmt.Printf("%*s└── ", 1, " ")
+      }
+
+      if appendProjectIDToTask {
+        fmt.Printf("%s [%s]\n", task, project)
+      } else {
+        fmt.Printf("%s\n", task)
+      }
+    }
+  }
+}
+
+func listProjectsAndTasks(entries []Entry) (map[string]map[string]bool, []string) {
+  var projectsAndTasks = make(map[string]map[string]bool)
+  var allTasks []string
+
+  for _, filteredEntry := range entries {
+    taskMap, ok := projectsAndTasks[filteredEntry.Project]
+
+    if !ok {
+      taskMap = make(map[string]bool)
+      projectsAndTasks[filteredEntry.Project] = taskMap
+    }
+
+    taskMap[filteredEntry.Task] = true
+    projectsAndTasks[filteredEntry.Project] = taskMap
+    allTasks = append(allTasks, filteredEntry.Task)
+  }
+
+  return projectsAndTasks, allTasks
+}
+
+

--- a/z/trackCmd.go
+++ b/z/trackCmd.go
@@ -70,4 +70,12 @@ func init() {
   trackCmd.Flags().StringVarP(&task, "task", "t", "", "Task to be assigned")
   trackCmd.Flags().StringVarP(&notes, "notes", "n", "", "Activity notes")
   trackCmd.Flags().BoolVarP(&force, "force", "f", false, "Force begin tracking of a new task \neven though another one is still running \n(ONLY IF YOU KNOW WHAT YOU'RE DOING!)")
+
+  flagName := "task"
+  trackCmd.RegisterFlagCompletionFunc(flagName, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+    user := GetCurrentUser()
+    entries, _ := database.ListEntries(user)
+    _, tasks := listProjectsAndTasks(entries)
+    return tasks, cobra.ShellCompDirectiveDefault
+  })
 }

--- a/z/trackCmd.go
+++ b/z/trackCmd.go
@@ -4,6 +4,7 @@ import (
   "os"
   "fmt"
   "github.com/spf13/cobra"
+  "github.com/spf13/viper"
 )
 
 var trackCmd = &cobra.Command{
@@ -21,6 +22,20 @@ var trackCmd = &cobra.Command{
 
     if runningEntryId != "" {
       fmt.Printf("%s a task is already running\n", CharTrack)
+      os.Exit(1)
+    }
+
+    if project == "" && viper.GetString("project.default") != "" {
+      project = viper.GetString("project.default")
+    }
+
+    if project == "" && viper.GetBool("project.mandatory") {
+      fmt.Println("project is mandatory but missing")
+      os.Exit(1)
+    }
+
+    if task == "" && viper.GetBool("task.mandatory") {
+      fmt.Println("task is mandatory but missing")
       os.Exit(1)
     }
 


### PR DESCRIPTION
PR 3 / 4. hopefully not to big in one step.

## Round to minutes

I don't need seconds, per minute base is enough. So i added an option that rounds all begin/finish times to full minute per truncating all (micro)seconds. Why: Because with seconds sometimes the sum does not fit because of rounding.
We also need to alter the IsFinishedBeforeBegan to accept equal times.

## project and task options

Added the option to make project and task mandatory. for Projects a default can set in config file

#### range besides since and until

since and until gives a good possibility to filter list and export for a given range. But entering two dates/times on daily basis is not very handy. So i added a range option that takes the mostly used ranges as texts: today, yesterday, this[week, month, year], last[week, month, year]

to deduplicate code - in particular for future features - the code blocks for parsing this was moved to helper.go

## Task shell-complete

Getting activities/tasks for listing was in the listCmd function. Moved to tasks, so getting tasks is reusable. So we can add a shell-completion function that can be used now with all Cmds which have a task flag.

## Concentrate track and finish functions in task

Moving more task functions into task.go file to avoid duplication in later functions 



