### PR TITLE
PR4: Adding new features

### DIFF
--- a/extras/zeit-sketchybar.sh
+++ b/extras/zeit-sketchybar.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+## Skeytchybar configuration:
+# sketchybar --add item zeit e \
+#            --set zeit icon=󱏁  \
+#                  script="$HOME/bin/zeit-sketchybar.sh" \
+#                  update_freq=15
+
+
+ZEIT_BIN=$HOME/bin/zeit
+SKETCHY_BIN=/opt/homebrew/bin/sketchybar
+
+line_identifier='^ ▶ tracking'
+
+tracking=$($ZEIT_BIN tracking --no-colors | grep "$line_identifier" | sed -e "s/$line_identifier//")
+
+echo $tracking
+$SKETCHY_BIN --set zeit label="$tracking"

--- a/z/resumeCmd.go
+++ b/z/resumeCmd.go
@@ -1,0 +1,21 @@
+package z
+
+import (
+  "github.com/spf13/cobra"
+)
+
+var resumeCmd = &cobra.Command{
+  Use:   "resume",
+  Short: "Resume last task",
+  Long:  "Track new activity with all parameters of the last task (based on begin time)",
+  Run: func(cmd *cobra.Command, args []string) {
+    resumeTask(1)
+  },
+}
+
+func init() {
+  rootCmd.AddCommand(resumeCmd)
+
+  resumeCmd.Flags().StringVarP(&begin, "begin", "b", "", "Time the activity should begin at\n\nEither in the formats 16:00 / 4:00PM \nor relative to the current time, \ne.g. -0:15 (now minus 15 minutes), +1.50 (now plus 1:30h).")
+  resumeCmd.Flags().StringVarP(&finish, "finish", "s", "", "Time the activity should finish at\n\nEither in the formats 16:00 / 4:00PM \nor relative to the current time, \ne.g. -0:15 (now minus 15 minutes), +1.50 (now plus 1:30h).\nMust be after --begin time.")
+}

--- a/z/rootCmd.go
+++ b/z/rootCmd.go
@@ -12,6 +12,7 @@ var database *Database
 
 var begin string
 var finish string
+var switchString string
 var project string
 var task string
 var notes string

--- a/z/switchBackCmd.go
+++ b/z/switchBackCmd.go
@@ -1,0 +1,26 @@
+package z
+
+import (
+  "github.com/spf13/cobra"
+)
+
+var switchBackCmd = &cobra.Command{
+  Use:   "switchback",
+  Short: "switchback to the task before the last one",
+  Long:  "End running activity and resume the task which was before, which can either be kept running until 'finish' is being called or parameterized to be a finished activity.",
+  Run: func(cmd *cobra.Command, args []string) {
+
+    finish = switchString
+    finishTask(FinishOnlyTime)
+
+    finish = ""
+    begin = switchString
+    resumeTask(2)
+  },
+}
+
+func init() {
+  rootCmd.AddCommand(switchBackCmd)
+
+  switchBackCmd.Flags().StringVarP(&switchString, "begin", "b", "", "Time the new activity should begin at and the old one ends\n\nEither in the formats 16:00 / 4:00PM \nor relative to the current time, \ne.g. -0:15 (now minus 15 minutes), +1.50 (now plus 1:30h).")
+}

--- a/z/switchCmd.go
+++ b/z/switchCmd.go
@@ -1,0 +1,38 @@
+package z
+
+import (
+  "github.com/spf13/cobra"
+)
+
+var switchCmd = &cobra.Command{
+  Use:   "switch",
+  Short: "switch to another task",
+  Long:  "End running activity and track new activity, which can either be kept running until 'finish' is being called or parameterized to be a finished activity.",
+  Run: func(cmd *cobra.Command, args []string) {
+
+    finish = switchString
+    finishTask(FinishOnlyTime)
+
+    finish = ""
+    begin = switchString
+    trackTask()
+  },
+}
+
+func init() {
+  rootCmd.AddCommand(switchCmd)
+
+  switchCmd.Flags().StringVarP(&switchString, "begin", "b", "", "Time the new activity should begin at and the old one ends\n\nEither in the formats 16:00 / 4:00PM \nor relative to the current time, \ne.g. -0:15 (now minus 15 minutes), +1.50 (now plus 1:30h).")
+  switchCmd.Flags().StringVarP(&project, "project", "p", "", "Project to be assigned")
+  switchCmd.Flags().StringVarP(&task, "task", "t", "", "Task to be assigned")
+  switchCmd.Flags().StringVarP(&notes, "notes", "n", "", "Activity notes")
+
+  flagName := "task"
+  switchCmd.RegisterFlagCompletionFunc(flagName, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+    user := GetCurrentUser()
+    entries, _ := database.ListEntries(user)
+    _, tasks := listProjectsAndTasks(entries)
+    return tasks, cobra.ShellCompDirectiveDefault
+  })
+}
+

--- a/z/task.go
+++ b/z/task.go
@@ -226,3 +226,47 @@ func taskGit(task *Task, runningEntry *Entry) {
   }
 }
 
+func resumeTask(index int) {
+  user := GetCurrentUser()
+
+  entries, err := database.ListEntries(user)
+  if err != nil {
+    fmt.Printf("%s %+v\n", CharError, err)
+    os.Exit(1)
+  }
+  lastEntry := entries[len(entries)-index]
+
+  runningEntryId, err := database.GetRunningEntryId(user)
+  if err != nil {
+    fmt.Printf("%s %+v\n", CharError, err)
+    os.Exit(1)
+  }
+
+  if runningEntryId != "" {
+    fmt.Printf("%s a task is already running\n", CharTrack)
+    os.Exit(1)
+  }
+
+  project = lastEntry.Project
+  task = lastEntry.Task
+
+  newEntry, err := NewEntry("", begin, finish, project, task, user)
+  if err != nil {
+    fmt.Printf("%s %+v\n", CharError, err)
+    os.Exit(1)
+  }
+
+  if lastEntry.Notes != "" {
+    newEntry.Notes = lastEntry.Notes
+  }
+
+  isRunning := newEntry.Finish.IsZero()
+
+  _, err = database.AddEntry(user, newEntry, isRunning)
+  if err != nil {
+    fmt.Printf("%s %+v\n", CharError, err)
+    os.Exit(1)
+  }
+
+  fmt.Print(newEntry.GetOutputForTrack(isRunning, false))
+}


### PR DESCRIPTION
PR 4/4, the last one in this series.

## New Functions resume / switch / switchback

Some processes that occur in my everyday work have required several steps or entries that can be avoided, so there are three new functions:

- resume: The last task (last entry in the list sorted by start time) is resumed - only the times are provided as parameters, otherwise it would not be the last task
- switch: I always have to interrupt my work due to meetings or operational activities. The switch is used to end the current task at the specified time (-b or now()) and start a new one with the specified parameters
- switchback: After the meeting, I want to resume the previous activity using -b to set the time of the switch

## New Function Report

In addition to the list and stats commands I created a report function which shows a summary per task on a daily base for a given timeframe with additional sums of daily work hours. 
One of the dependencies required a newer version of go than 1.18, I made an upgrade to 1.23. (1.24 was released only last week, than was a bit to new)

## Sketchy-Integration extra

As discussed I moved the sketchy integration into a extra shell script now and out of the go code. I did not work on the --format feature, this would need a bit more preparation as I'm not sure if I understood all use-cases of the existing paths. 