### PR TITLE
Update README with completion instructions for other shells

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,8 +49,19 @@ source <(zeit completion bash)
 To load completions for every new session, add them to your completions
 directory, e.g.:
 
+Bash:
 ```
 sudo zeit completion bash > /etc/bash_completion.d/zeit
+```
+
+Zsh:
+```
+sudo zeit completion zsh > (one of your completion dirs at $fpath)/_zeit
+```
+
+Fish:
+```
+sudo zeit completion fish > (one of your completion dirs at $fish_complete_path)/zeit.fish
 ```
 
 ### Projects


### PR DESCRIPTION
Added instructions for loading completions in Zsh, and Fish.

I rarely add my own completions since [zsh-users/zsh-completions](https://github.com/zsh-users/zsh-completions) has covered for me well. So I don't remember zsh having to require underscore in their completion _filename until it wasn't loading for me even if it was in the completions path. 

I've never used powershell but hopefully having these other examples will help guide people in the right direction. Feel free to edit to suit your writing style.

----- 

sidenote: I found this tool in your cool minimalist website by the way. I'm also curious about your coffee journal cli as well since I've been brewing my own filter coffee but it's been a while since I tracked my progress. ☕️